### PR TITLE
Fix docs link locations

### DIFF
--- a/index.html
+++ b/index.html
@@ -428,11 +428,11 @@
                         <ul class="list-unstyled li-space-lg">
                           <li class="media">
                             <i class="fas fa-square"></i>
-                            <div class="media-body"><a href="https://docs.k8sproject.io/getting-started" class="primary">Get Started</a></div>
+                            <div class="media-body"><a href="https://github.com/k0sproject/k0s#cluster-bootstrapping" class="primary">Get Started</a></div>
                           </li>
                           <li class="media">
                             <i class="fas fa-square"></i>
-                            <div class="media-body"><a href="https://docs.k0sproject.io" class="primary">Documentation</a></div>
+                            <div class="media-body"><a href="https://github.com/k0sproject/k0s/tree/main/docs" class="primary">Documentation</a></div>
                           </li>
                           <li class="media">
                             <i class="fas fa-square"></i>


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

We don't yet have the docs site built, so point docs links directly to the main repo instead for now.