### PR TITLE
Update GET STARTED button to point to stable docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <a class="nav-link" href="https://docs.k0sproject.io" target="_blank">DOCS</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="https://docs.k0sproject.io/latest/install/" target="_blank">GET STARTED</a>
+        <a class="nav-link" href="https://docs.k0sproject.io/stable/install/" target="_blank">GET STARTED</a>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="https://medium.com/k0sproject" target="_blank">BLOG</a>


### PR DESCRIPTION
For some reason /latest/ points to 1.23.6.0+k0s.2. This doesn't solve this issue but pointing to stable fixes the link.