### PR TITLE
Replace latest with stable in k0s docs links

### DIFF
--- a/contact-us.html
+++ b/contact-us.html
@@ -173,7 +173,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                     <ul class="list-unstyled li-space-lg">
                       <li class="media">
                         <i class="fas fa-square"></i>
-                        <div class="media-body"><a href="https://docs.k0sproject.io/latest/install/" class="primary">Get Started</a></div>
+                        <div class="media-body"><a href="https://docs.k0sproject.io/stable/install/" class="primary">Get Started</a></div>
                       </li>
                       <li class="media">
                         <i class="fas fa-square"></i>

--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             <p class="p-large">The Simple, Solid & Certified Kubernetes Distribution</p>
             <h1>THE KUBERNETES <br>FOR <span id="js-rotating">PUBLIC CLOUD, PRIVATE CLOUD, HYBRID CLOUD, ON-PREMISES, BARE METAL, EDGE, IOT</span></h1>
             <p class="p-large">Deploy and run Kubernetes workloads at any scale on any infrastructure.<br/>All batteries included. 100% open source & free.</p>
-            <a class="btn-solid-lg" href="https://docs.k0sproject.io/latest/install/" target="_blank"><i class="fas fa-external-link-alt"></i> Get Started</a>
+            <a class="btn-solid-lg" href="https://docs.k0sproject.io/stable/install/" target="_blank"><i class="fas fa-external-link-alt"></i> Get Started</a>
           </div>
         </div> <!-- end of col -->
       </div>
@@ -418,7 +418,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                     <div class="text-container">
                       <h2>Get Started</h2>
                       <p class="p-large"><span class="k0s-typography">k0s</span> is the simple, solid & certified Kubernetes distribution that works on any infrastructure: bare-metal, on-premises, edge, IoT, public & private clouds. It's 100% open source & free. Get started today!</p>
-                      <a class="btn-solid-lg" href="https://docs.k0sproject.io/latest/install/" target="_blank"><i class="fas fa-external-link-alt"></i> Get Started</a>
+                      <a class="btn-solid-lg" href="https://docs.k0sproject.io/stable/install/" target="_blank"><i class="fas fa-external-link-alt"></i> Get Started</a>
                     </div> <!-- end of text-container -->
                 </div> <!-- end of col -->
                 <div class="col-lg-6 col-xl-7">
@@ -447,7 +447,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                         <ul class="list-unstyled li-space-lg">
                           <li class="media">
                             <i class="fas fa-square"></i>
-                            <div class="media-body"><a href="https://docs.k0sproject.io/latest/install/" class="primary">Get Started</a></div>
+                            <div class="media-body"><a href="https://docs.k0sproject.io/stable/install/" class="primary">Get Started</a></div>
                           </li>
                           <li class="media">
                             <i class="fas fa-square"></i>


### PR DESCRIPTION
The latest alias is no longer used in the k0s docs for quite some time. Fix this oversight by changing all occurrences to stable, which is used nowadays.

Fixes k0sproject/k0s#3708.