### PR TITLE
Remove Kubernetes 1.26 from list of supported versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,7 +191,6 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
               <li class=" "><span class="value">v1.29</span></li>
               <li class=" "><span class="value">v1.28</span></li>
               <li class=" "><span class="value">v1.27</span></li>
-              <li class=" "><span class="value">v1.26</span></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
Official EOL date is 2024-02-28. The latest round of upstream patch releases didn't include 1.26 anymore.